### PR TITLE
fix same candidates appearing multiple times in table

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2,27 +2,39 @@ App = {
   web3Provider: null,
   contracts: {},
   account: '0x0',
-  hasVoted: false,
 
   init: function() {
     return App.initWeb3();
   },
 
   initWeb3: function() {
-    // TODO: refactor conditional
-    if (typeof web3 !== 'undefined') {
-      // If a web3 instance is already provided by Meta Mask.
-      App.web3Provider = web3.currentProvider;
-      web3 = new Web3(web3.currentProvider);
-    } else {
-      // Specify default instance if no web3 instance provided
+  //   if (typeof web3 !== 'undefined') {
+  //     // If a web3 instance is already provided by Meta Mask.
+  //     App.web3Provider = web3.currentProvider;
+  //     web3 = new Web3(web3.currentProvider);
+  //   } else {
+  //     // Specify default instance if no web3 instance provided
+  //     App.web3Provider = new Web3.providers.HttpProvider('http://localhost:7545');
+  //     web3 = new Web3(App.web3Provider);
+  //   }
+  //   return App.initContract();
+  // },
+
+    if (window.ethereum) {
+      App.web3Provider = window.ethereum;
+      window.ethereum.enable();
+      web3 = new Web3(App.web3Provider);
+      return App.initContract();
+    }
+    else {
       App.web3Provider = new Web3.providers.HttpProvider('http://localhost:7545');
       web3 = new Web3(App.web3Provider);
+      return App.initContract();
     }
-    return App.initContract();
   },
 
-  initContract: function() {
+
+  initContract: async function() {
     $.getJSON("Election.json", function(election) {
       // Instantiate a new truffle contract from the artifact
       App.contracts.Election = TruffleContract(election);
@@ -31,7 +43,20 @@ App = {
 
       App.listenForEvents();
 
-      return App.render();
+      App.render();
+      });
+    },
+
+   castVote: function() {
+    var candidateId = $('#candidatesSelect').val();
+    App.contracts.Election.deployed().then(function(instance) {
+      return instance.vote(candidateId, { from: App.account });
+    }).then(function(result) {
+      // Wait for votes to update
+      $("#content").hide();
+      $("#loader").show();
+    }).catch(function(err) {
+      console.error(err);
     });
   },
 
@@ -73,17 +98,20 @@ App = {
       electionInstance = instance;
       return electionInstance.candidatesCount();
     }).then(function(candidatesCount) {
-      var candidatesResults = $("#candidatesResults");
-      candidatesResults.empty();
-
-      var candidatesSelect = $('#candidatesSelect');
-      candidatesSelect.empty();
-
+      var candArray = [];
       for (var i = 1; i <= candidatesCount; i++) {
-        electionInstance.candidates(i).then(function(candidate) {
-          var id = candidate[0];
-          var name = candidate[1];
-          var voteCount = candidate[2];
+        candArray.push(electionInstance.candidates(i));
+      }
+      Promise.all(candArray).then(function(candArray) {
+          var candidatesResults = $("#candidatesResults");
+          candidatesResults.empty();
+
+          var candidatesSelect = $('#candidatesSelect');
+          candidatesSelect.empty();
+        for (var i = 0; i < candidatesCount; i++) {
+          var id = candArray[i][0];
+          var name = candArray[i][1];
+          var voteCount = candArray[i][2];
 
           // Render candidate Result
           var candidateTemplate = "<tr><th>" + id + "</th><td>" + name + "</td><td>" + voteCount + "</td></tr>"
@@ -92,8 +120,8 @@ App = {
           // Render candidate ballot option
           var candidateOption = "<option value='" + id + "' >" + name + "</ option>"
           candidatesSelect.append(candidateOption);
-        });
-      }
+        }
+      });
       return electionInstance.voters(App.account);
     }).then(function(hasVoted) {
       // Do not allow a user to vote


### PR DESCRIPTION
Key changes:

Use Promise.all so all candidates are available for synchronous table update for each render() call.
Now, for two candidates, the table update would be like: (cand1 from 1st render call + cand2 from 1st) update done for 1st render … 2nd render …

Previously, multiple render() calls mixed up promises, so the table sometimes returned strange result: (cand1 from 1st + cand1 from 2nd + cand2 from 1st + cand2 from 2nd) update done for 1st and 2nd render() calls at the same time but the table showed each candidate twice.