### PR TITLE
Added 'memory' to addCandidate function arguments

### DIFF
--- a/contracts/Election.sol
+++ b/contracts/Election.sol
@@ -26,7 +26,7 @@ contract Election {
         addCandidate("Candidate 2");
     }
 
-    function addCandidate (string _name) private {
+    function addCandidate (string memory _name) private {
         candidatesCount ++;
         candidates[candidatesCount] = Candidate(candidatesCount, _name, 0);
     }


### PR DESCRIPTION
I'm using solidity 5.0 + and I had to add 'memory' to the addCandidate function to compile and deploy. Not sure if you will find this useful or if most people are still using < 5.0