### PR TITLE
Update app.js

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -61,12 +61,20 @@ App = {
     content.hide();
 
     // Load account data
-    web3.eth.getCoinbase(function(err, account) {
-      if (err === null) {
-        App.account = account;
-        $("#accountAddress").html("Your Account: " + account);
-      }
-    });
+    if(ethereum){
+        ethereum.enable().then(function(acc){
+            App.account = acc[0];
+            $("#accountAddress").html("Your Account: " + App.account);
+        });
+    }
+    else {
+       web3.eth.getCoinbase(function(err, account) {
+        if (err === null) {
+          App.account = account;
+          $("#accountAddress").html("Your Account: " + account);
+        }
+      });
+    }
 
     // Load contract data
     App.contracts.Election.deployed().then(function(instance) {


### PR DESCRIPTION
The current way of loading the account data is deprecated (works in Edge, but not on Chrome)
Added a check if window.ethereum is available
Loads and enables the metamask wallet data
Accesses data from the 
If not (the case for edge) - continues to use the old way of loading the data